### PR TITLE
For macOS: return focus to main window after closing dialog

### DIFF
--- a/oshw-qt/TWMainWnd.cpp
+++ b/oshw-qt/TWMainWnd.cpp
@@ -1102,6 +1102,10 @@ int TileWorldMainWnd::DisplayEndMessage(int nBaseScore, int nTimeScore, long lTo
 		
 		msgBox.exec();
 		ReleaseAllKeys();
+
+		// macOS *does* return focus to the main window after closing the
+		// victory dialog; this is here in case that changes
+		this->activateWindow();
 		if (msgBox.clickedButton() == pBtnRestart)
 			return CmdSameLevel;
 			
@@ -1155,6 +1159,9 @@ int TileWorldMainWnd::DisplayEndMessage(int nBaseScore, int nTimeScore, long lTo
 		}
 		msgBox.exec();
 		ReleaseAllKeys();
+		// macOS doesn't return focus to the main window after closing the death
+		// dialog; this fixes that
+		this->activateWindow();
 	}
 	
 	return CmdProceed;


### PR DESCRIPTION
There's a strange behavior on macOS where focus does not return to the main window after closing the death message box. It *does* work after closing the victory window. I suspect this is because the death dialog is simpler (i.e. it doesn't have any HTML formatting or custom icons) so it uses the more "modern" (and crappier) dialog box introduced with a post-Apple Silicon version of macOS a few years back.

Anyway, this PR adds `this->activateWindow()` after closing *both* message boxes, just in case the victory dialog also breaks in the future.